### PR TITLE
Issues with SI.Distance and MB.World

### DIFF
--- a/PlanarMechanics/GearComponents/Examples/Utilities/RigidNoLossPlanetary.mo
+++ b/PlanarMechanics/GearComponents/Examples/Utilities/RigidNoLossPlanetary.mo
@@ -3,7 +3,7 @@ model RigidNoLossPlanetary "planetary gearbox"
   extends
     PlanarMechanics.GearComponents.Examples.Utilities.Interfaces.PlanetaryGearInterface;
 
-      parameter SI.Distance r_s(start=1) "radius of sun gear";
+  parameter SI.Distance r_s(start=1) "radius of sun gear";
   parameter SI.Distance r_p(start=1) "radius of planet gear";
   parameter SI.Distance r_r(start=3) "radius of ring gear";
 

--- a/PlanarMechanics/GearComponents/RigidNoLossExternal.mo
+++ b/PlanarMechanics/GearComponents/RigidNoLossExternal.mo
@@ -4,7 +4,7 @@ model RigidNoLossExternal "External rigid gear gonnection model"
   extends
     PlanarMechanics.GearComponents.Examples.Utilities.Interfaces.TwoPlanarConnectorsHeat;
 
-      parameter SI.Distance r_a=1 "radius of Gear A";
+  parameter SI.Distance r_a=1 "radius of Gear A";
   parameter SI.Distance r_b=1 "radius of Gear B";
 
   parameter Boolean animate = true "= true, if animation shall be enabled" annotation(Evaluate=true, HideResult=true);

--- a/PlanarMechanics/Joints/DryFrictionBasedRolling.mo
+++ b/PlanarMechanics/Joints/DryFrictionBasedRolling.mo
@@ -18,7 +18,7 @@ model DryFrictionBasedRolling
 
   parameter Boolean animate = true "enable Animation"
                                                      annotation(Dialog(group="Animation"));
-  SI.Position x(stateSelect=stateSelect,start = 0) "horizontal position" annotation(Dialog(group="Initialization", showStartAttribute=true));
+  SI.Position x(stateSelect=stateSelect,start = 0) "Horizontal position" annotation(Dialog(group="Initialization", showStartAttribute=true));
   SI.Angle phi(stateSelect=stateSelect,start = 0) "Angular position" annotation(Dialog(group="Initialization", showStartAttribute=true));
   SI.AngularVelocity w(stateSelect=stateSelect,start = 0) "Angular velocity" annotation(Dialog(group="Initialization", showStartAttribute=true));
   SI.AngularAcceleration z(start = 0) "Angular acceleration"

--- a/PlanarMechanics/Joints/Prismatic.mo
+++ b/PlanarMechanics/Joints/Prismatic.mo
@@ -13,13 +13,13 @@ model Prismatic "A prismatic joint"
   parameter StateSelect stateSelect=StateSelect.default
     "Priority to use acceleration as states" annotation(HideResult=true,Dialog(tab="Advanced"));
 
-  parameter SI.Distance r[2] "direction of the rod wrt. body system at phi=0";
+  parameter SI.Position r[2] "direction of the rod wrt. body system at phi=0";
   final parameter SI.Length l = sqrt(r*r) "lengt of r";
   final parameter SI.Distance e[2]= r/l "normalized r";
-  SI.Distance s(final stateSelect = stateSelect, start = 0)
+  SI.Position s(final stateSelect = stateSelect, start = 0)
     "Elongation of the joint";
   Real e0[2] "direction of the prismatic rod resolved wrt.inertial frame";
-  SI.Distance r0[2]
+  SI.Position r0[2]
     "translation vector of the prismatic rod resolved wrt.inertial frame";
   Real R[2,2] "Rotation Matrix";
   SI.Velocity v(final stateSelect = stateSelect, start = 0)
@@ -41,7 +41,7 @@ model Prismatic "A prismatic joint"
       group="if animation = true",
       enable=animate));
   parameter SI.Distance boxWidth=l/planarWorld.defaultWidthFraction
-    " Width of prismatic joint box"
+    "Width of prismatic joint box"
     annotation (Dialog(tab="Animation", group="if animation = true", enable=animation));
   input Types.Color boxColor=Types.Defaults.JointColor
     "Color of prismatic joint box"

--- a/PlanarMechanics/Joints/Revolute.mo
+++ b/PlanarMechanics/Joints/Revolute.mo
@@ -1,5 +1,5 @@
 within PlanarMechanics.Joints;
-model Revolute "A revolute joint "
+model Revolute "A revolute joint"
 
   Interfaces.Frame_a frame_a
     annotation (Placement(transformation(extent={{-110,-10},{-90,10}}),

--- a/PlanarMechanics/Parts/Damper.mo
+++ b/PlanarMechanics/Parts/Damper.mo
@@ -28,14 +28,14 @@ outer PlanarWorld planarWorld "planar world model";
   parameter SI.Length zPosition = planarWorld.defaultZPosition
     "z position of cylinder representing the fixed translation" annotation (Dialog(
       tab="Animation", group="if animation = true", enable=animate));
-  parameter SI.Distance length_a = planarWorld.defaultForceLength
-    " Length of cylinder at frame_a side"
+  parameter SI.Length length_a = planarWorld.defaultForceLength
+    "Length of cylinder at frame_a side"
     annotation (Dialog(tab="Animation", group="if animation = true", enable=animate));
   input SI.Diameter diameter_a = planarWorld.defaultForceWidth
-    " Diameter of cylinder at frame_a side"
+    "Diameter of cylinder at frame_a side"
     annotation (Dialog(tab="Animation", group="if animation = true", enable=animate));
   input SI.Diameter diameter_b = 0.6*diameter_a
-    " Diameter of cylinder at frame_b side"
+    "Diameter of cylinder at frame_b side"
     annotation (Dialog(tab="Animation", group="if animation = true", enable=animate));
   input Types.Color color_a = {100,100,100} " Color at frame_a"
     annotation (Dialog(tab="Animation", group="if animation = true", enable=animate, colorSelector));

--- a/PlanarMechanics/Parts/FixedRotation.mo
+++ b/PlanarMechanics/Parts/FixedRotation.mo
@@ -10,10 +10,10 @@ model FixedRotation "A fixed translation between two components (rigid rod)"
       tab="Animation",
       group="if animation = true",
       enable=animate));
-  parameter SI.Distance cylinderLength=planarWorld.defaultJointLength
+  parameter SI.Length cylinderLength=planarWorld.defaultJointLength
     "Length of cylinder representing the fixed rotation"
     annotation (Dialog(tab="Animation", group="if animation = true", enable=animate));
-  parameter SI.Distance cylinderDiameter=planarWorld.defaultJointWidth
+  parameter SI.Length cylinderDiameter=planarWorld.defaultJointWidth
     "Diameter of cylinder representing the fixed rotation"
     annotation (Dialog(tab="Animation", group="if animation = true", enable=animate));
   input Modelica.Mechanics.MultiBody.Types.Color cylinderColor={155,155,155}

--- a/PlanarMechanics/Parts/FixedTranslation.mo
+++ b/PlanarMechanics/Parts/FixedTranslation.mo
@@ -10,7 +10,7 @@ model FixedTranslation "A fixed translation between two components (rigid rod)"
   parameter SI.Length r[2] = {1,0}
     "length of the rod resolved w.r.t to body frame at phi = 0";
   final parameter SI.Length l = sqrt(r*r);
-  SI.Distance r0[2] "length of the rod resolved w.r.t to inertal frame";
+  SI.Position r0[2] "length of the rod resolved w.r.t to inertal frame";
   Real R[2,2] "Rotation matrix";
   parameter Boolean animate = true "= true, if animation shall be enabled"
                                            annotation(Dialog(group="Animation"));
@@ -18,7 +18,7 @@ model FixedTranslation "A fixed translation between two components (rigid rod)"
     "z position of cylinder representing the fixed translation" annotation (Dialog(
       tab="Animation", group="if animation = true", enable=animate));
   parameter SI.Distance width=l/planarWorld.defaultWidthFraction
-    " Width of shape"
+    "Width of shape"
     annotation (Dialog(tab="Animation", group="if animation = true", enable=animation));
   input Modelica.Mechanics.MultiBody.Types.SpecularCoefficient
     specularCoefficient = planarWorld.defaultSpecularCoefficient

--- a/PlanarMechanics/Parts/Spring.mo
+++ b/PlanarMechanics/Parts/Spring.mo
@@ -36,20 +36,20 @@ model Spring "Linear 2D translational spring"
   parameter SI.Length zPosition = planarWorld.defaultZPosition
     "z position of cylinder representing the fixed translation" annotation (Dialog(
       tab="Animation", group="if animation = true", enable=animate));
-  parameter Integer numberOfWindings = 5 " Number of spring windings"
+  parameter Integer numberOfWindings = 5 "Number of spring windings"
     annotation (Dialog(tab="Animation", group="if animation = true", enable=animate));
-  input SI.Position width = planarWorld.defaultForceWidth " Width of spring"
+  input SI.Position width = planarWorld.defaultForceWidth "Width of spring"
     annotation (Dialog(tab="Animation", group="if animation = true", enable=animate));
-  input SI.Position coilWidth = width/10 " Width of spring coil"
+  input SI.Position coilWidth = width/10 "Width of spring coil"
     annotation (Dialog(tab="Animation", group="if animation = true", enable=animate));
   input Modelica.Mechanics.MultiBody.Types.SpecularCoefficient
     specularCoefficient = planarWorld.defaultSpecularCoefficient
     "Reflection of ambient light (= 0: light is completely absorbed)"
     annotation (Dialog(tab="Animation", group="if animation = true", enable=animate));
-  input Types.Color color = Types.Defaults.SpringColor " Color of spring"
+  input Types.Color color = Types.Defaults.SpringColor "Color of spring"
     annotation (Dialog(tab="Animation", group="if animation = true", enable=animate));
 
-  SI.Distance length
+  SI.Length length
     "Distance between the origin of frame_a and the origin of frame_b";
   SI.Position r_rel_0[3]
     "Position vector from frame_a to frame_b resolved in world frame";

--- a/PlanarMechanics/Parts/SpringDamper.mo
+++ b/PlanarMechanics/Parts/SpringDamper.mo
@@ -45,33 +45,33 @@ model SpringDamper "Linear 2D translational spring damper model"
   parameter SI.Length zPosition = planarWorld.defaultZPosition
     "z position of cylinder representing the fixed translation" annotation (Dialog(
       tab="Animation", group="if animation = true", enable=animate));
-  parameter Integer numberOfWindings = 5 " Number of spring windings"
+  parameter Integer numberOfWindings = 5 "Number of spring windings"
     annotation (Dialog(tab="Animation", group="if animation = true", enable=animate));
-  input SI.Distance width = planarWorld.defaultForceWidth " Width of spring"
+  input SI.Length width = planarWorld.defaultForceWidth "Width of spring"
     annotation (Dialog(tab="Animation", group="if animation = true", enable=animate));
-  input SI.Distance coilWidth = width/10 " Width of spring coil"
+  input SI.Length coilWidth = width/10 "Width of spring coil"
     annotation (Dialog(tab="Animation", group="if animation = true", enable=animate));
   input Modelica.Mechanics.MultiBody.Types.SpecularCoefficient
     specularCoefficient = planarWorld.defaultSpecularCoefficient
     "Reflection of ambient light (= 0: light is completely absorbed)"
     annotation (Dialog(tab="Animation", group="if animation = true", enable=animate));
-  input Types.Color color = Types.Defaults.SpringColor " Color of spring"
+  input Types.Color color = Types.Defaults.SpringColor "Color of spring"
     annotation (Dialog(tab="Animation", group="if animation = true", enable=animate));
-  parameter SI.Distance length_a = planarWorld.defaultForceLength
-    " Length of cylinder at frame_a side"
+  parameter SI.Length length_a = planarWorld.defaultForceLength
+    "Length of cylinder at frame_a side"
     annotation (Dialog(tab="Animation", group="if animation = true", enable=animate));
   input SI.Diameter diameter_a = planarWorld.defaultForceWidth
-    " Diameter of cylinder at frame_a side"
+    "Diameter of cylinder at frame_a side"
     annotation (Dialog(tab="Animation", group="if animation = true", enable=animate));
   input SI.Diameter diameter_b = 0.6*diameter_a
-    " Diameter of cylinder at frame_b side"
+    "Diameter of cylinder at frame_b side"
     annotation (Dialog(tab="Animation", group="if animation = true", enable=animate));
-  input Types.Color color_a = {100,100,100} " Color at frame_a"
+  input Types.Color color_a = {100,100,100} "Color at frame_a"
     annotation (Dialog(tab="Animation", group="if animation = true", enable=animate, colorSelector));
-  input Types.Color color_b = {155,155,155} " Color at frame_b"
+  input Types.Color color_b = {155,155,155} "Color at frame_b"
     annotation (Dialog(tab="Animation", group="if animation = true", enable=animate, colorSelector));
 
-  SI.Distance length
+  SI.Length length
     "Distance between the origin of frame_a and the origin of frame_b";
   SI.Position r_rel_0[3]
     "Position vector from frame_a to frame_b resolved in world frame";

--- a/PlanarMechanics/PlanarWorld.mo
+++ b/PlanarMechanics/PlanarWorld.mo
@@ -14,10 +14,10 @@ model PlanarWorld
   parameter SI.Acceleration[2] g={0,-9.81}
     "Constant gravity acceleration vector resolved in world frame";
 
-  parameter SI.Distance axisLength=nominalLength/2
+  parameter SI.Length axisLength=nominalLength/2
     "Length of world axes arrows"
     annotation (Dialog(tab="Animation", group="if animateWorld = true", enable=enableAnimation and animateWorld));
-  parameter SI.Distance axisDiameter=axisLength/defaultFrameDiameterFraction
+  parameter SI.Diameter axisDiameter=axisLength/defaultFrameDiameterFraction
     "Diameter of world axes arrows"
     annotation (Dialog(tab="Animation", group="if animateWorld = true", enable=enableAnimation and animateWorld));
   parameter Boolean axisShowLabels=true "= true, if labels shall be shown"
@@ -55,13 +55,13 @@ model PlanarWorld
   parameter SI.Length defaultJointWidth=nominalLength/10
     "Default for the fixed width of a shape representing a joint"
     annotation (Dialog(tab="Defaults"));
-  parameter SI.Length defaultBodyDiameter=nominalLength/9
+  parameter SI.Diameter defaultBodyDiameter=nominalLength/9
     "Default for diameter of sphere representing the center of mass of a body"
     annotation (Dialog(tab="Defaults"));
   parameter Real defaultWidthFraction=20
     "Default for shape width as a fraction of shape length (e.g., for Parts.FixedTranslation)"
     annotation (Dialog(tab="Defaults"));
-  parameter SI.Length defaultArrowDiameter=nominalLength/40
+  parameter SI.Diameter defaultArrowDiameter=nominalLength/40
     "Default for arrow diameter (e.g., of forces, torques, sensors)"
     annotation (Dialog(tab="Defaults"));
   parameter SI.Length defaultForceLength=nominalLength/10

--- a/PlanarMechanics/Sensors/CutForce.mo
+++ b/PlanarMechanics/Sensors/CutForce.mo
@@ -16,10 +16,10 @@ model CutForce "Measure cut force vector"
     "= true, if force with positive sign is returned (= frame_a.f), otherwise with negative sign (= frame_b.f)";
 
   input Real N_to_m(unit="N/m") = 1000
-    " Force arrow scaling (length = force/N_to_m)"
+    "Force arrow scaling (length = force/N_to_m)"
     annotation (Dialog(group="if animation = true", enable=animation));
   input SI.Diameter forceDiameter=planarWorld.defaultArrowDiameter
-    " Diameter of force arrow" annotation (Dialog(group="if animation = true", enable=animation));
+    "Diameter of force arrow" annotation (Dialog(group="if animation = true", enable=animation));
   input Types.Color forceColor=Modelica.Mechanics.MultiBody.Types.Defaults.
       ForceColor " Color of force arrow"
     annotation (Dialog(group="if animation = true", enable=animation));
@@ -30,6 +30,7 @@ model CutForce "Measure cut force vector"
   extends Internal.PartialCutForceSensor;
 
 protected
+ inner Modelica.Mechanics.MultiBody.World world;
   SI.Position f_in_m[3]={frame_a.fx, frame_a.fy, 0}*(if positiveSign then +1 else -1)/N_to_m
     "Force mapped from N to m for animation";
   Modelica.Mechanics.MultiBody.Visualizers.Advanced.Arrow forceArrow(

--- a/PlanarMechanics/Sensors/CutForceAndTorque.mo
+++ b/PlanarMechanics/Sensors/CutForceAndTorque.mo
@@ -44,6 +44,7 @@ model CutForceAndTorque "Measure cut force and cut torque vector"
   extends Internal.PartialCutForceSensor;
 
 protected
+ inner Modelica.Mechanics.MultiBody.World world;
   parameter Integer csign=if positiveSign then +1 else -1;
   SI.Position f_in_m[3]={frame_a.fx, frame_a.fy, 0}*csign/N_to_m
     "Force mapped from N to m for animation";

--- a/PlanarMechanics/Sensors/CutTorque.mo
+++ b/PlanarMechanics/Sensors/CutTorque.mo
@@ -28,6 +28,7 @@ model CutTorque "Measure cut torque vector"
     annotation (Dialog(group="if animation = true", enable=animation));
 
 protected
+ inner Modelica.Mechanics.MultiBody.World world;
   SI.Position t_in_m[3]={0,0,frame_a.t}*(if positiveSign then +1 else -1)/Nm_to_m
     "Torque mapped from Nm to m for animation";
   Modelica.Mechanics.MultiBody.Visualizers.Advanced.DoubleArrow torqueArrow(

--- a/PlanarMechanics/Sensors/Distance.mo
+++ b/PlanarMechanics/Sensors/Distance.mo
@@ -30,6 +30,7 @@ model Distance
     "Prevent zero-division if distance between frame_a and frame_b is zero"
    annotation (Dialog(tab="Advanced"));
 protected
+ inner Modelica.Mechanics.MultiBody.World world;
  Modelica.Mechanics.MultiBody.Visualizers.Advanced.Arrow arrow(
    r={frame_a.x, frame_a.y, 0},
    r_head={frame_b.x, frame_b.y, 0} - {frame_a.x, frame_a.y, 0},

--- a/PlanarMechanics/Sources/QuadraticSpeedDependantForce.mo
+++ b/PlanarMechanics/Sources/QuadraticSpeedDependantForce.mo
@@ -49,7 +49,7 @@ public
     annotation (Placement(transformation(extent={{80,-20},{120,20}})));
 
   Interfaces.Frame_resolve frame_resolve(fx = 0, fy = 0, t = 0) if resolveInFrameB == Modelica.Mechanics.MultiBody.Types.ResolveInFrameB.frame_resolve
-    "Coordinate system in which vector is optionally resolved, if useExtraFrame is true "
+    "Coordinate system in which vector is optionally resolved, if useExtraFrame is true"
                                                                                             annotation (
       Placement(transformation(extent={{0,-60},{20,-40}}), iconTransformation(
           extent={{-40,-40},{-20,-20}})));

--- a/PlanarMechanics/Sources/RelativeForce.mo
+++ b/PlanarMechanics/Sources/RelativeForce.mo
@@ -35,7 +35,7 @@ outer PlanarWorld planarWorld "planar world model";
   SI.Angle phi "rotation angle of the additional frame_c";
 
   Interfaces.Frame_resolve frame_resolve(fx = 0, fy = 0, t = 0, phi = phi) if resolveInFrame == Modelica.Mechanics.MultiBody.Types.ResolveInFrameAB.frame_resolve
-    "Coordinate system in which vector is optionally resolved, if useExtraFrame is true "
+    "Coordinate system in which vector is optionally resolved, if useExtraFrame is true"
                                                                                             annotation (
       Placement(transformation(extent={{0,-60},{20,-40}}), iconTransformation(
           extent={{-40,-40},{-20,-20}})));

--- a/PlanarMechanics/Sources/WorldForce.mo
+++ b/PlanarMechanics/Sources/WorldForce.mo
@@ -38,7 +38,7 @@ model WorldForce
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
 
   Interfaces.Frame_resolve frame_resolve(fx = 0, fy = 0, t = 0, phi = phi) if resolveInFrame == Modelica.Mechanics.MultiBody.Types.ResolveInFrameB.frame_resolve
-    "Coordinate system in which vector is optionally resolved, if useExtraFrame is true "
+    "Coordinate system in which vector is optionally resolved, if useExtraFrame is true"
                                                                                             annotation (
       Placement(transformation(extent={{0,-60},{20,-40}}), iconTransformation(
           extent={{-40,-40},{-20,-20}})));

--- a/PlanarMechanics/Visualizers/Advanced/Arrow.mo
+++ b/PlanarMechanics/Visualizers/Advanced/Arrow.mo
@@ -27,7 +27,7 @@ model Arrow
                                                                                                         annotation(Dialog);
 
 protected
-  outer PlanarMechanics.PlanarWorld planarWorld;
+  outer PlanarWorld planarWorld;
   SI.Length length=Modelica.Math.Vectors.length(r_head) "Length of arrow";
   Real e_x[3](each final unit="1", start={1,0,0}) = noEvent(if length < 1.e-10 then {1,0,0} else r_head/length);
   Real rxvisobj[3](each final unit="1") = transpose(R.T)*e_x

--- a/PlanarMechanics/Visualizers/Advanced/DoubleArrow.mo
+++ b/PlanarMechanics/Visualizers/Advanced/DoubleArrow.mo
@@ -27,7 +27,7 @@ model DoubleArrow
                                                                                                         annotation(Dialog);
 
 protected
-  outer PlanarMechanics.PlanarWorld planarWorld;
+  outer PlanarWorld planarWorld;
   SI.Length length=Modelica.Math.Vectors.length(r_head) "Length of arrow";
   Real e_x[3](each final unit="1", start={1,0,0}) = noEvent(if length < 1.e-10 then {1,0,0} else r_head/length);
   Real rxvisobj[3](each final unit="1") = transpose(R.T)*e_x


### PR DESCRIPTION
- Added inner Modelica.Mechanics.MultiBody.World as required by Modelica.Mechanics.MultiBody.Visualizers.Advanced.Arrow and Modelica.Mechanics.MultiBody.Visualizers.Advanced.DoubleArrow
- The state variable PlanarMechanics.Joints.Prismatic.s is of type Modelica.SIunits.Distance which means that the minimum length is zero. This is not suitable for simulation with negative elongations. See also [Mo#446](https://trac.modelica.org/Modelica/ticket/446) where there was the same problem.
- Did some cosmetics.
