### PR TITLE
Extracted a base class for wheel implementations

### DIFF
--- a/PlanarMechanics/VehicleComponents/Wheels/BaseClasses/WheelBase.mo
+++ b/PlanarMechanics/VehicleComponents/Wheels/BaseClasses/WheelBase.mo
@@ -50,13 +50,13 @@ partial model WheelBase
           fillColor={231,231,231}),
         Text(
           extent={{-150,-58},{150,-88}},
-          lineColor={0,0,0},
+          textColor={0,0,0},
           textString="radius=%radius"),
         Text(
           extent={{-150,140},{150,100}},
           textString="%name",
-          lineColor={0,0,255})}), Diagram(coordinateSystem(
-          preserveAspectRatio=false)),
+          textColor={0,0,255})}),
+    Diagram(coordinateSystem(preserveAspectRatio=false)),
     Documentation(info="<html>
 <p>
 This partial class contains common connectors needed for wheel models

--- a/PlanarMechanics/VehicleComponents/Wheels/BaseClasses/WheelBase.mo
+++ b/PlanarMechanics/VehicleComponents/Wheels/BaseClasses/WheelBase.mo
@@ -1,0 +1,57 @@
+within PlanarMechanics.VehicleComponents.Wheels.BaseClasses;
+partial model WheelBase
+  Interfaces.Frame_a frame_a annotation (Placement(transformation(extent={{-54,-16},
+            {-22,16}})));
+  Modelica.Mechanics.Rotational.Interfaces.Flange_a flange_a annotation (
+      Placement(transformation(extent={{90,-10},{110,10}}),iconTransformation(
+          extent={{90,-10},{110,10}})));
+  annotation (Icon(coordinateSystem(preserveAspectRatio=false), graphics={
+        Rectangle(
+          extent={{-40,100},{40,-100}},
+          lineColor={95,95,95},
+          fillPattern=FillPattern.HorizontalCylinder,
+          fillColor={231,231,231}),
+        Line(
+          points={{-40,30},{40,30}},
+          color={95,95,95}),
+        Line(
+          points={{-40,-30},{40,-30}},
+          color={95,95,95}),
+        Line(
+          points={{-40,60},{40,60}},
+          color={95,95,95}),
+        Line(
+          points={{-40,80},{40,80}},
+          color={95,95,95}),
+        Line(
+          points={{-40,90},{40,90}},
+          color={95,95,95}),
+        Line(
+          points={{-40,100},{40,100}},
+          color={95,95,95}),
+        Line(
+          points={{-40,-80},{40,-80}},
+          color={95,95,95}),
+        Line(
+          points={{-40,-90},{40,-90}},
+          color={95,95,95}),
+        Line(
+          points={{-40,-100},{40,-100}},
+          color={95,95,95}),
+        Line(
+          points={{-40,-60},{40,-60}},
+          color={95,95,95}),
+        Rectangle(
+          extent={{100,10},{40,-10}},
+          fillPattern=FillPattern.HorizontalCylinder,
+          fillColor={231,231,231}),
+        Text(
+          extent={{-150,-58},{150,-88}},
+          lineColor={0,0,0},
+          textString="radius=%radius"),
+        Text(
+          extent={{-150,140},{150,100}},
+          textString="%name",
+          lineColor={0,0,255})}), Diagram(coordinateSystem(
+          preserveAspectRatio=false)));
+end WheelBase;

--- a/PlanarMechanics/VehicleComponents/Wheels/BaseClasses/WheelBase.mo
+++ b/PlanarMechanics/VehicleComponents/Wheels/BaseClasses/WheelBase.mo
@@ -1,11 +1,14 @@
 within PlanarMechanics.VehicleComponents.Wheels.BaseClasses;
 partial model WheelBase
+  "Partial base class containing wheel upright's frame and drive flange"
   Interfaces.Frame_a frame_a annotation (Placement(transformation(extent={{-54,-16},
             {-22,16}})));
   Modelica.Mechanics.Rotational.Interfaces.Flange_a flange_a annotation (
       Placement(transformation(extent={{90,-10},{110,10}}),iconTransformation(
           extent={{90,-10},{110,10}})));
-  annotation (Icon(coordinateSystem(preserveAspectRatio=false), graphics={
+  annotation (
+    Icon(coordinateSystem(preserveAspectRatio=false),
+      graphics={
         Rectangle(
           extent={{-40,100},{40,-100}},
           lineColor={95,95,95},
@@ -53,5 +56,16 @@ partial model WheelBase
           extent={{-150,140},{150,100}},
           textString="%name",
           lineColor={0,0,255})}), Diagram(coordinateSystem(
-          preserveAspectRatio=false)));
+          preserveAspectRatio=false)),
+    Documentation(info="<html>
+<p>
+This partial class contains common connectors needed for wheel models
+and a&nbsp;simple icon. In particular, <code>frame_a</code> shall be
+connected to a&nbsp;wheel carrier (also called upright) and
+<code>flange_a</code> is intended to connect a&nbsp;driveline.
+This class should be extended to create
+a&nbsp;proper model, see e.g.
+<a href=\"modelica://PlanarMechanics.VehicleComponents.Wheels.IdealWheelJoint\">IdealWheelJoint</a> model.
+</p>
+</html>"));
 end WheelBase;

--- a/PlanarMechanics/VehicleComponents/Wheels/BaseClasses/WheelBase.mo
+++ b/PlanarMechanics/VehicleComponents/Wheels/BaseClasses/WheelBase.mo
@@ -1,11 +1,10 @@
 within PlanarMechanics.VehicleComponents.Wheels.BaseClasses;
 partial model WheelBase
-  "Partial base class containing wheel upright's frame and drive flange"
-  Interfaces.Frame_a frame_a annotation (Placement(transformation(extent={{-54,-16},
-            {-22,16}})));
-  Modelica.Mechanics.Rotational.Interfaces.Flange_a flange_a annotation (
-      Placement(transformation(extent={{90,-10},{110,10}}),iconTransformation(
-          extent={{90,-10},{110,10}})));
+  "Enhanced partial base class containing wheel interfaces and icon"
+  extends WheelInterfaces;
+
+  parameter SI.Length radius "Wheel radius";
+
   annotation (
     Icon(coordinateSystem(preserveAspectRatio=false),
       graphics={
@@ -48,6 +47,11 @@ partial model WheelBase
           extent={{100,10},{40,-10}},
           fillPattern=FillPattern.HorizontalCylinder,
           fillColor={231,231,231}),
+        Line(
+          visible=useHeatPort,
+          points={{-100,-100},{-30,-100}},
+          color={191,0,0},
+          smooth=Smooth.None),
         Text(
           extent={{-150,-58},{150,-88}},
           textColor={0,0,0},
@@ -59,13 +63,17 @@ partial model WheelBase
     Diagram(coordinateSystem(preserveAspectRatio=false)),
     Documentation(info="<html>
 <p>
-This partial class contains common connectors needed for wheel models
-and a&nbsp;simple icon. In particular, <code>frame_a</code> shall be
-connected to a&nbsp;wheel carrier (also called upright) and
-<code>flange_a</code> is intended to connect a&nbsp;driveline.
-This class should be extended to create
+This partial class contains common connectors needed for wheel models,
+a&nbsp;simple icon and some parameters. This class should be extended to create
 a&nbsp;proper model, see e.g.
 <a href=\"modelica://PlanarMechanics.VehicleComponents.Wheels.IdealWheelJoint\">IdealWheelJoint</a> model.
 </p>
+<p>
+Note: If this model is used, the loss power has to be provided by an equation
+in the model which inherits from the
+</p>
+<blockquote><pre>
+WheelInterfaces model(<strong>lossPower = ...</strong>).
+</pre></blockquote>
 </html>"));
 end WheelBase;

--- a/PlanarMechanics/VehicleComponents/Wheels/BaseClasses/WheelInterfaces.mo
+++ b/PlanarMechanics/VehicleComponents/Wheels/BaseClasses/WheelInterfaces.mo
@@ -1,0 +1,30 @@
+within PlanarMechanics.VehicleComponents.Wheels.BaseClasses;
+partial model WheelInterfaces "Partial base class containing common wheel interfaces"
+  extends Modelica.Thermal.HeatTransfer.Interfaces.PartialElementaryConditionalHeatPortWithoutT;
+  Interfaces.Frame_a frame_a annotation (Placement(transformation(extent={{-54,-16},
+            {-22,16}})));
+  Modelica.Mechanics.Rotational.Interfaces.Flange_a flange_a annotation (
+      Placement(transformation(extent={{90,-10},{110,10}}),iconTransformation(
+          extent={{90,-10},{110,10}})));
+  annotation (
+    Icon(coordinateSystem(preserveAspectRatio=false)),
+    Diagram(coordinateSystem(preserveAspectRatio=false)),
+    Documentation(info="<html>
+<p>
+This partial class contains common connectors needed for wheel models.
+In particular, <code>frame_a</code> is intended to connected a&nbsp;wheel
+carrier (also called upright) and <code>flange_a</code> to connect
+a&nbsp;driveline.
+This class should be extended to create
+a&nbsp;proper model, see e.g.
+<a href=\"modelica://PlanarMechanics.VehicleComponents.Wheels.IdealWheelJoint\">IdealWheelJoint</a> model.
+</p>
+<p>
+Note: If this model is used, the loss power has to be provided by an equation
+in the model which inherits from the
+</p>
+<blockquote><pre>
+WheelInterfaces model(<strong>lossPower = ...</strong>).
+</pre></blockquote>
+</html>"));
+end WheelInterfaces;

--- a/PlanarMechanics/VehicleComponents/Wheels/BaseClasses/package.mo
+++ b/PlanarMechanics/VehicleComponents/Wheels/BaseClasses/package.mo
@@ -1,0 +1,4 @@
+within PlanarMechanics.VehicleComponents.Wheels;
+package BaseClasses
+  extends Modelica.Icons.BasesPackage;
+end BaseClasses;

--- a/PlanarMechanics/VehicleComponents/Wheels/BaseClasses/package.mo
+++ b/PlanarMechanics/VehicleComponents/Wheels/BaseClasses/package.mo
@@ -1,4 +1,11 @@
 within PlanarMechanics.VehicleComponents.Wheels;
-package BaseClasses
+package BaseClasses "Collection of base classes for wheels"
   extends Modelica.Icons.BasesPackage;
+
+  annotation (Documentation(info="<html>
+<p>
+A&nbsp;collection of base classes for planar wheel models.
+These partial classes should be extended to create proper models.
+</p>
+</html>"));
 end BaseClasses;

--- a/PlanarMechanics/VehicleComponents/Wheels/BaseClasses/package.order
+++ b/PlanarMechanics/VehicleComponents/Wheels/BaseClasses/package.order
@@ -1,1 +1,2 @@
+WheelInterfaces
 WheelBase

--- a/PlanarMechanics/VehicleComponents/Wheels/BaseClasses/package.order
+++ b/PlanarMechanics/VehicleComponents/Wheels/BaseClasses/package.order
@@ -1,0 +1,1 @@
+WheelBase

--- a/PlanarMechanics/VehicleComponents/Wheels/DryFrictionWheelJoint.mo
+++ b/PlanarMechanics/VehicleComponents/Wheels/DryFrictionWheelJoint.mo
@@ -1,12 +1,8 @@
 within PlanarMechanics.VehicleComponents.Wheels;
 model DryFrictionWheelJoint "Dry-Friction based wheel joint"
+  extends PlanarMechanics.VehicleComponents.Wheels.BaseClasses.WheelBase;
   extends Modelica.Thermal.HeatTransfer.Interfaces.PartialElementaryConditionalHeatPort(
     final T=293.15);
-  Interfaces.Frame_a frame_a annotation (Placement(transformation(extent={{-56,-16},
-            {-24,16}})));
-  Modelica.Mechanics.Rotational.Interfaces.Flange_a flange_a annotation (
-      Placement(transformation(extent={{90,-8},{110,12}}), iconTransformation(
-          extent={{90,-10},{110,10}})));
   outer PlanarWorld planarWorld "planar world model";
   parameter StateSelect stateSelect=StateSelect.default
     "Priority to use acceleration as states" annotation(HideResult=true,Dialog(tab="Advanced"));
@@ -124,59 +120,12 @@ equation
   f_lat = {frame_a.fy, -frame_a.fx}*e0;
   lossPower = f*v_slip;
   annotation (Icon(graphics={
-        Rectangle(
-          extent={{-40,100},{40,-100}},
-          lineColor={95,95,95},
-          fillPattern=FillPattern.HorizontalCylinder,
-          fillColor={231,231,231}),
-        Line(
-          points={{-40,30},{40,30}},
-          color={95,95,95}),
-        Line(
-          points={{-40,-30},{40,-30}},
-          color={95,95,95}),
-        Line(
-          points={{-40,60},{40,60}},
-          color={95,95,95}),
-        Line(
-          points={{-40,80},{40,80}},
-          color={95,95,95}),
-        Line(
-          points={{-40,90},{40,90}},
-          color={95,95,95}),
-        Line(
-          points={{-40,100},{40,100}},
-          color={95,95,95}),
-        Line(
-          points={{-40,-80},{40,-80}},
-          color={95,95,95}),
-        Line(
-          points={{-40,-90},{40,-90}},
-          color={95,95,95}),
-        Line(
-          points={{-40,-100},{40,-100}},
-          color={95,95,95}),
-        Line(
-          points={{-40,-60},{40,-60}},
-          color={95,95,95}),
-        Rectangle(
-          extent={{100,10},{40,-10}},
-          fillPattern=FillPattern.HorizontalCylinder,
-          fillColor={231,231,231}),
         Line(
           visible=useHeatPort,
           points={{-100,-100},{-100,-90},{0,-90}},
           color={191,0,0},
           pattern=LinePattern.Dot,
-          smooth=Smooth.None),
-        Text(
-          extent={{-150,-110},{150,-140}},
-          textColor={0,0,0},
-          textString="radius=%radius"),
-        Text(
-          extent={{-150,140},{150,100}},
-          textString="%name",
-          textColor={0,0,255})}),
+          smooth=Smooth.None)}),
     Documentation(
       info="<html>
 <p>The ideal wheel joint models the behavior of a wheel rolling on a x,y-plane whose contact patch has dry-friction characteristics. This is an approximation for stiff wheels without a tire.</p>

--- a/PlanarMechanics/VehicleComponents/Wheels/DryFrictionWheelJoint.mo
+++ b/PlanarMechanics/VehicleComponents/Wheels/DryFrictionWheelJoint.mo
@@ -1,13 +1,11 @@
 within PlanarMechanics.VehicleComponents.Wheels;
 model DryFrictionWheelJoint "Dry-Friction based wheel joint"
   extends PlanarMechanics.VehicleComponents.Wheels.BaseClasses.WheelBase;
-  extends Modelica.Thermal.HeatTransfer.Interfaces.PartialElementaryConditionalHeatPort(
-    final T=293.15);
+
   outer PlanarWorld planarWorld "planar world model";
   parameter StateSelect stateSelect=StateSelect.default
     "Priority to use acceleration as states" annotation(HideResult=true,Dialog(tab="Advanced"));
 
-  parameter SI.Length radius "Radius of the wheel";
   parameter SI.Length r[2] "Driving direction of the wheel at angle phi = 0";
   parameter SI.Force N "Normal force";
   parameter SI.Velocity vAdhesion "Adhesion velocity";
@@ -80,8 +78,8 @@ model DryFrictionWheelJoint "Dry-Friction based wheel joint"
     widthDirection={1,0,0},
     r_shape={0,0,-radius},
     r=MB.Frames.resolve1(planarWorld.R,{frame_a.x,frame_a.y,zPosition})+planarWorld.r_0,
-    R=MB.Frames.absoluteRotation(planarWorld.R,MB.Frames.planarRotation({-e0[2],e0[1],0},flange_a.phi,0))) if
-         planarWorld.enableAnimation and animate;
+    R=MB.Frames.absoluteRotation(planarWorld.R,MB.Frames.planarRotation({-e0[2],e0[1],0},flange_a.phi,0)))
+    if planarWorld.enableAnimation and animate;
   MB.Visualizers.Advanced.Shape rim2(
     shapeType="cylinder",
     color={195,195,195},
@@ -93,8 +91,8 @@ model DryFrictionWheelJoint "Dry-Friction based wheel joint"
     widthDirection={1,0,0},
     r_shape={0,0,-radius},
     r=MB.Frames.resolve1(planarWorld.R,{frame_a.x,frame_a.y,zPosition})+planarWorld.r_0,
-    R=MB.Frames.absoluteRotation(planarWorld.R,MB.Frames.planarRotation({-e0[2],e0[1],0},flange_a.phi+Modelica.Constants.pi/2,0))) if
-        planarWorld.enableAnimation and animate;
+    R=MB.Frames.absoluteRotation(planarWorld.R,MB.Frames.planarRotation({-e0[2],e0[1],0},flange_a.phi+Modelica.Constants.pi/2,0)))
+    if planarWorld.enableAnimation and animate;
 equation
   R = {{cos(frame_a.phi), -sin(frame_a.phi)}, {sin(frame_a.phi),cos(frame_a.phi)}};
   e0 = R*e;
@@ -119,13 +117,8 @@ equation
   f_long = {frame_a.fx, frame_a.fy}*e0;
   f_lat = {frame_a.fy, -frame_a.fx}*e0;
   lossPower = f*v_slip;
-  annotation (Icon(graphics={
-        Line(
-          visible=useHeatPort,
-          points={{-100,-100},{-100,-90},{0,-90}},
-          color={191,0,0},
-          pattern=LinePattern.Dot,
-          smooth=Smooth.None)}),
+
+  annotation (
     Documentation(
       info="<html>
 <p>The ideal wheel joint models the behavior of a wheel rolling on a x,y-plane whose contact patch has dry-friction characteristics. This is an approximation for stiff wheels without a tire.</p>

--- a/PlanarMechanics/VehicleComponents/Wheels/IdealWheelJoint.mo
+++ b/PlanarMechanics/VehicleComponents/Wheels/IdealWheelJoint.mo
@@ -1,11 +1,11 @@
 within PlanarMechanics.VehicleComponents.Wheels;
 model IdealWheelJoint "Ideal wheel joint"
-  extends PlanarMechanics.VehicleComponents.Wheels.BaseClasses.WheelBase;
+  extends PlanarMechanics.VehicleComponents.Wheels.BaseClasses.WheelBase(
+    final useHeatPort=false);
   outer PlanarWorld planarWorld "planar world model";
   parameter StateSelect stateSelect=StateSelect.default
     "Priority to use acceleration as states" annotation(HideResult=true,Dialog(tab="Advanced"));
 
-  parameter SI.Length radius "Radius of the wheel";
   parameter SI.Length r[2] "Driving direction of the wheel at angle phi = 0";
   final parameter SI.Length l = Modelica.Math.Vectors.length(r) "Length of r";
   final parameter Real e[2](each final unit="1") = Modelica.Math.Vectors.normalizeWithAssert(r)
@@ -65,8 +65,8 @@ model IdealWheelJoint "Ideal wheel joint"
     widthDirection={1,0,0},
     r_shape={0,0,-radius},
     r=MB.Frames.resolve1(planarWorld.R,{frame_a.x,frame_a.y,zPosition})+planarWorld.r_0,
-    R=MB.Frames.absoluteRotation(planarWorld.R,MB.Frames.planarRotation({-e0[2],e0[1],0},flange_a.phi,0))) if
-        planarWorld.enableAnimation and animate;
+    R=MB.Frames.absoluteRotation(planarWorld.R,MB.Frames.planarRotation({-e0[2],e0[1],0},flange_a.phi,0)))
+    if planarWorld.enableAnimation and animate;
   MB.Visualizers.Advanced.Shape rim2(
     shapeType="cylinder",
     color={195,195,195},
@@ -78,8 +78,8 @@ model IdealWheelJoint "Ideal wheel joint"
     widthDirection={1,0,0},
     r_shape={0,0,-radius},
     r=MB.Frames.resolve1(planarWorld.R,{frame_a.x,frame_a.y,zPosition})+planarWorld.r_0,
-    R=MB.Frames.absoluteRotation(planarWorld.R,MB.Frames.planarRotation({-e0[2],e0[1],0},flange_a.phi+Modelica.Constants.pi/2,0))) if
-        planarWorld.enableAnimation and animate;
+    R=MB.Frames.absoluteRotation(planarWorld.R,MB.Frames.planarRotation({-e0[2],e0[1],0},flange_a.phi+Modelica.Constants.pi/2,0)))
+    if planarWorld.enableAnimation and animate;
 equation
   R = {{cos(frame_a.phi), -sin(frame_a.phi)}, {sin(frame_a.phi),cos(frame_a.phi)}};
   e0 = R*e;
@@ -92,6 +92,8 @@ equation
   -f_long*radius = flange_a.tau;
   frame_a.t = 0;
   {frame_a.fx, frame_a.fy}*e0 = f_long;
+  lossPower = 0;
+
   annotation (
     Documentation(
       info="<html>

--- a/PlanarMechanics/VehicleComponents/Wheels/IdealWheelJoint.mo
+++ b/PlanarMechanics/VehicleComponents/Wheels/IdealWheelJoint.mo
@@ -1,11 +1,6 @@
 within PlanarMechanics.VehicleComponents.Wheels;
 model IdealWheelJoint "Ideal wheel joint"
-
-  Interfaces.Frame_a frame_a annotation (Placement(transformation(extent={{-56,-16},
-            {-24,16}})));
-  Modelica.Mechanics.Rotational.Interfaces.Flange_a flange_a annotation (
-      Placement(transformation(extent={{90,-8},{110,12}}), iconTransformation(
-          extent={{90,-10},{110,10}})));
+  extends PlanarMechanics.VehicleComponents.Wheels.BaseClasses.WheelBase;
   outer PlanarWorld planarWorld "planar world model";
   parameter StateSelect stateSelect=StateSelect.default
     "Priority to use acceleration as states" annotation(HideResult=true,Dialog(tab="Advanced"));
@@ -97,54 +92,7 @@ equation
   -f_long*radius = flange_a.tau;
   frame_a.t = 0;
   {frame_a.fx, frame_a.fy}*e0 = f_long;
-  annotation (Icon(graphics={
-        Rectangle(
-          extent={{-40,100},{40,-100}},
-          lineColor={95,95,95},
-          fillPattern=FillPattern.HorizontalCylinder,
-          fillColor={231,231,231}),
-        Line(
-          points={{-40,30},{40,30}},
-          color={95,95,95}),
-        Line(
-          points={{-40,-30},{40,-30}},
-          color={95,95,95}),
-        Line(
-          points={{-40,60},{40,60}},
-          color={95,95,95}),
-        Line(
-          points={{-40,80},{40,80}},
-          color={95,95,95}),
-        Line(
-          points={{-40,90},{40,90}},
-          color={95,95,95}),
-        Line(
-          points={{-40,100},{40,100}},
-          color={95,95,95}),
-        Line(
-          points={{-40,-80},{40,-80}},
-          color={95,95,95}),
-        Line(
-          points={{-40,-90},{40,-90}},
-          color={95,95,95}),
-        Line(
-          points={{-40,-100},{40,-100}},
-          color={95,95,95}),
-        Line(
-          points={{-40,-60},{40,-60}},
-          color={95,95,95}),
-        Rectangle(
-          extent={{100,10},{40,-10}},
-          fillPattern=FillPattern.HorizontalCylinder,
-          fillColor={231,231,231}),
-        Text(
-          extent={{-150,-110},{150,-140}},
-          textColor={0,0,0},
-          textString="radius=%radius"),
-        Text(
-          extent={{-150,140},{150,100}},
-          textString="%name",
-          textColor={0,0,255})}),
+  annotation (
     Documentation(
       info="<html>
 <p>The ideal wheel joint enforces the constraints of ideal rolling on the x,y-plane.</p>

--- a/PlanarMechanics/VehicleComponents/Wheels/SlipBasedWheelJoint.mo
+++ b/PlanarMechanics/VehicleComponents/Wheels/SlipBasedWheelJoint.mo
@@ -1,11 +1,8 @@
 within PlanarMechanics.VehicleComponents.Wheels;
 model SlipBasedWheelJoint "Slip-Friction based wheel joint"
+  extends PlanarMechanics.VehicleComponents.Wheels.BaseClasses.WheelBase;
   extends Modelica.Thermal.HeatTransfer.Interfaces.PartialElementaryConditionalHeatPort(
     final T=293.15);
-  Interfaces.Frame_a frame_a annotation (Placement(transformation(extent={{-56,-16},
-            {-24,16}})));
-  Modelica.Mechanics.Rotational.Interfaces.Flange_a flange_a annotation (
-      Placement(transformation(extent={{90,-10},{110,10}})));
   Modelica.Blocks.Interfaces.RealInput dynamicLoad(unit="N") annotation (Placement(transformation(
         extent={{20,-20},{-20,20}},
         rotation=270,
@@ -137,56 +134,12 @@ equation
   f_lat = {frame_a.fy, -frame_a.fx}*e0;
   lossPower = f*v_slip;
   annotation (Icon(graphics={
-        Rectangle(
-          extent={{-40,100},{40,-100}},
-          lineColor={95,95,95},
-          fillPattern=FillPattern.HorizontalCylinder,
-          fillColor={231,231,231}),
-        Line(
-          points={{-40,30},{40,30}},
-          color={95,95,95}),
-        Line(
-          points={{-40,-30},{40,-30}},
-          color={95,95,95}),
-        Line(
-          points={{-40,60},{40,60}},
-          color={95,95,95}),
-        Line(
-          points={{-40,80},{40,80}},
-          color={95,95,95}),
-        Line(
-          points={{-40,90},{40,90}},
-          color={95,95,95}),
-        Line(
-          points={{-40,100},{40,100}},
-          color={95,95,95}),
-        Line(
-          points={{-40,-80},{40,-80}},
-          color={95,95,95}),
-        Line(
-          points={{-40,-90},{40,-90}},
-          color={95,95,95}),
-        Line(
-          points={{-40,-100},{40,-100}},
-          color={95,95,95}),
-        Rectangle(
-          extent={{100,10},{40,-10}},
-          fillPattern=FillPattern.HorizontalCylinder,
-          fillColor={231,231,231}),
         Line(
           visible=useHeatPort,
           points={{-100,-100},{-100,-90},{-30,-90}},
           color={191,0,0},
           pattern=LinePattern.Dot,
-          smooth=Smooth.None),
-        Text(
-          extent={{-150,-40},{150,-70}},
-          textColor={0,0,0},
-          textString="radius=%radius"),
-        Text(
-          extent={{-150,140},{150,100}},
-          textString="%name",
-          textColor={0,0,255})}),
+          smooth=Smooth.None)}),
     Documentation(
       info="<html>
 <p>The ideal wheel joint models the behavior of a wheel rolling on a x,y-plane whose contact patch has slip-dependent friction characteristics. This is an approximation for wheels with a rim and a rupper tire.</p>

--- a/PlanarMechanics/VehicleComponents/Wheels/SlipBasedWheelJoint.mo
+++ b/PlanarMechanics/VehicleComponents/Wheels/SlipBasedWheelJoint.mo
@@ -1,8 +1,7 @@
 within PlanarMechanics.VehicleComponents.Wheels;
 model SlipBasedWheelJoint "Slip-Friction based wheel joint"
   extends PlanarMechanics.VehicleComponents.Wheels.BaseClasses.WheelBase;
-  extends Modelica.Thermal.HeatTransfer.Interfaces.PartialElementaryConditionalHeatPort(
-    final T=293.15);
+
   Modelica.Blocks.Interfaces.RealInput dynamicLoad(unit="N") annotation (Placement(transformation(
         extent={{20,-20},{-20,20}},
         rotation=270,
@@ -12,7 +11,6 @@ model SlipBasedWheelJoint "Slip-Friction based wheel joint"
 
   parameter StateSelect stateSelect=StateSelect.default
     "Priority to use acceleration as states" annotation(HideResult=true,Dialog(tab="Advanced"));
-  parameter SI.Length radius "Radius of the wheel";
   parameter SI.Length r[2] "Driving direction of the wheel at angle phi = 0";
   parameter SI.Force N "Base normal load";
   parameter SI.Velocity vAdhesion_min "Minimum adhesion velocity";
@@ -91,8 +89,8 @@ model SlipBasedWheelJoint "Slip-Friction based wheel joint"
     widthDirection={1,0,0},
     r_shape={0,0,-radius},
     r=MB.Frames.resolve1(planarWorld.R,{frame_a.x,frame_a.y,zPosition})+planarWorld.r_0,
-    R=MB.Frames.absoluteRotation(planarWorld.R,MB.Frames.planarRotation({-e0[2],e0[1],0},flange_a.phi,0))) if
-      planarWorld.enableAnimation and animate;
+    R=MB.Frames.absoluteRotation(planarWorld.R,MB.Frames.planarRotation({-e0[2],e0[1],0},flange_a.phi,0)))
+    if planarWorld.enableAnimation and animate;
   MB.Visualizers.Advanced.Shape rim2(
     shapeType="cylinder",
     color={195,195,195},
@@ -104,8 +102,8 @@ model SlipBasedWheelJoint "Slip-Friction based wheel joint"
     widthDirection={1,0,0},
     r_shape={0,0,-radius},
     r=MB.Frames.resolve1(planarWorld.R,{frame_a.x,frame_a.y,zPosition})+planarWorld.r_0,
-    R=MB.Frames.absoluteRotation(planarWorld.R,MB.Frames.planarRotation({-e0[2],e0[1],0},flange_a.phi+Modelica.Constants.pi/2,0))) if
-      planarWorld.enableAnimation and animate;
+    R=MB.Frames.absoluteRotation(planarWorld.R,MB.Frames.planarRotation({-e0[2],e0[1],0},flange_a.phi+Modelica.Constants.pi/2,0)))
+    if planarWorld.enableAnimation and animate;
 equation
   R = {{cos(frame_a.phi), -sin(frame_a.phi)}, {sin(frame_a.phi),cos(frame_a.phi)}};
   e0 = R*e;
@@ -133,13 +131,8 @@ equation
   f_long = {frame_a.fx, frame_a.fy}*e0;
   f_lat = {frame_a.fy, -frame_a.fx}*e0;
   lossPower = f*v_slip;
-  annotation (Icon(graphics={
-        Line(
-          visible=useHeatPort,
-          points={{-100,-100},{-100,-90},{-30,-90}},
-          color={191,0,0},
-          pattern=LinePattern.Dot,
-          smooth=Smooth.None)}),
+
+  annotation (
     Documentation(
       info="<html>
 <p>The ideal wheel joint models the behavior of a wheel rolling on a x,y-plane whose contact patch has slip-dependent friction characteristics. This is an approximation for wheels with a rim and a rupper tire.</p>

--- a/PlanarMechanics/VehicleComponents/Wheels/package.order
+++ b/PlanarMechanics/VehicleComponents/Wheels/package.order
@@ -1,3 +1,4 @@
 IdealWheelJoint
 DryFrictionWheelJoint
 SlipBasedWheelJoint
+BaseClasses


### PR DESCRIPTION
This is done to separate the wheel interface from the implementation. This facilitates own wheel implementations and allows changing wheel implementations in models by using the Modelica "replacable" and "constrainedby".