### PR TITLE
Reintroduce arrow's diameter parameter

### DIFF
--- a/PlanarMechanics/Sensors/CutForce.mo
+++ b/PlanarMechanics/Sensors/CutForce.mo
@@ -18,6 +18,9 @@ model CutForce "Measure cut force vector"
   input Real N_to_m(unit="N/m") = planarWorld.defaultN_to_m
     "Force arrow scaling (length = force/N_to_m)"
     annotation (Dialog(group="if animation = true", enable=animation));
+  input SI.Diameter forceDiameter = planarWorld.defaultArrowDiameter
+    "Has no longer an effect and is only kept for backwards compatibility (arrow visualization by Vector now)"
+    annotation (Dialog(group="if animation = true", enable=animation));
   input MB.Types.Color forceColor = Modelica.Mechanics.MultiBody.Types.Defaults.ForceColor
     "Color of force arrow"
     annotation (HideResult=true, Dialog(colorSelector=true, group="if animation = true", enable=animation));

--- a/PlanarMechanics/Sensors/CutForceAndTorque.mo
+++ b/PlanarMechanics/Sensors/CutForceAndTorque.mo
@@ -31,6 +31,12 @@ model CutForceAndTorque "Measure cut force vector and cut torque"
   input Real Nm_to_m(unit="N.m/m") = planarWorld.defaultNm_to_m
     "Torque arrow scaling (length = torque/Nm_to_m)"
     annotation (Dialog(group="if animation = true", enable=animation));
+  input SI.Diameter forceDiameter = planarWorld.defaultArrowDiameter
+    "Has no longer an effect and is only kept for backwards compatibility (arrow visualization by Vector now)"
+    annotation (Dialog(group="if animation = true", enable=animation));
+  input SI.Diameter torqueDiameter = forceDiameter
+    "Has no longer an effect and is only kept for backwards compatibility (arrow visualization by Vector now)"
+    annotation (Dialog(group="if animation = true", enable=animation));
   input MB.Types.Color forceColor = Modelica.Mechanics.MultiBody.Types.Defaults.ForceColor
     "Color of force arrow"
     annotation (HideResult=true, Dialog(colorSelector=true, group="if animation = true", enable=animation));

--- a/PlanarMechanics/Sensors/CutTorque.mo
+++ b/PlanarMechanics/Sensors/CutTorque.mo
@@ -19,6 +19,9 @@ model CutTorque "Measure cut torque"
   input Real Nm_to_m(unit="N.m/m") = planarWorld.defaultNm_to_m
     "Torque arrow scaling (length = torque/Nm_to_m)"
     annotation (Dialog(group="if animation = true", enable=animation));
+  input SI.Diameter torqueDiameter = planarWorld.defaultArrowDiameter
+    "Has no longer an effect and is only kept for backwards compatibility (arrow visualization by Vector now)"
+    annotation (Dialog(group="if animation = true", enable=animation));
   input MB.Types.Color torqueColor = Modelica.Mechanics.MultiBody.Types.Defaults.TorqueColor
     "Color of torque arrow"
     annotation (HideResult=true, Dialog(colorSelector=true, group="if animation = true", enable=animation));

--- a/PlanarMechanics/Sources/QuadraticSpeedDependentForce.mo
+++ b/PlanarMechanics/Sources/QuadraticSpeedDependentForce.mo
@@ -31,6 +31,9 @@ public
     "Torque arrow scaling (length = torque/Nm_to_m)"
     annotation (Dialog(tab="Animation",group="If animation = true", enable=animation));
 
+  input SI.Diameter diameter=planarWorld.defaultArrowDiameter
+    "Has no longer an effect and is only kept for backwards compatibility (arrow visualization by Vector now)"
+    annotation (Dialog(tab="Animation",group="If animation = true", enable=animation));
   parameter SI.Length zPosition = planarWorld.defaultZPosition
     "Position z of cylinder representing the fixed translation" annotation (Dialog(
       tab="Animation",group="If animation = true", enable=animation));

--- a/PlanarMechanics/Sources/RelativeForce.mo
+++ b/PlanarMechanics/Sources/RelativeForce.mo
@@ -14,6 +14,9 @@ model RelativeForce "Input signal acting as force and torque on two frames"
     "Torque arrow scaling (length = torque/Nm_to_m)"
     annotation (Dialog(tab="Animation",group="If animation = true", enable=animation));
 
+  input SI.Diameter diameter=planarWorld.defaultArrowDiameter
+    "Has no longer an effect and is only kept for backwards compatibility (arrow visualization by Vector now)"
+    annotation (Dialog(tab="Animation",group="If animation = true", enable=animation));
   parameter SI.Length zPosition = planarWorld.defaultZPosition
     "Position z of cylinder representing the fixed translation"
     annotation (Dialog(tab="Animation",group="If animation = true", enable=animation));

--- a/PlanarMechanics/Sources/WorldForce.mo
+++ b/PlanarMechanics/Sources/WorldForce.mo
@@ -16,6 +16,9 @@ model WorldForce
     "Torque arrow scaling (length = torque/Nm_to_m)"
     annotation (Dialog(tab="Animation",group="If animation = true", enable=animation));
 
+  input SI.Diameter diameter = planarWorld.defaultArrowDiameter
+    "Has no longer an effect and is only kept for backwards compatibility (arrow visualization by Vector now)"
+    annotation (Dialog(tab="Animation",group="If animation = true", enable=animation));
   parameter SI.Length zPosition = planarWorld.defaultZPosition
     "Position z of cylinder representing the fixed translation"
     annotation (Dialog(tab="Animation",group="If animation = true", enable=animation));

--- a/PlanarMechanics/package.mo
+++ b/PlanarMechanics/package.mo
@@ -19,9 +19,8 @@ package PlanarMechanics "Library to model 2-dimensional, planar mechanical syste
       from(
         version={"1.4.1","1.4.0"},
         script="modelica://PlanarMechanics/Resources/Scripts/Conversion/ConvertFromPlanarMechanics_1_4_1.mos"),
-      from(
-        version={"1.5.1","1.5.0"},
-        script="modelica://PlanarMechanics/Resources/Scripts/Conversion/ConvertFromPlanarMechanics_1_5_0.mos")),
+      noneFromVersion="1.5.0",
+      noneFromVersion="1.5.1"),
     Documentation(
       info="<html>
 <p>


### PR DESCRIPTION
The parameters have no longer an effect and are reintroduced only for backwards compatibility.