### PR TITLE
Use default colors

### DIFF
--- a/PlanarMechanics/Sensors/CutForce.mo
+++ b/PlanarMechanics/Sensors/CutForce.mo
@@ -18,7 +18,7 @@ model CutForce "Measure cut force vector"
   input Real N_to_m(unit="N/m") = planarWorld.defaultN_to_m
     "Force arrow scaling (length = force/N_to_m)"
     annotation (Dialog(group="if animation = true", enable=animation));
-  input MB.Types.Color forceColor = Modelica.Mechanics.MultiBody.Types.Defaults.ForceColor
+  input MB.Types.Color forceColor = PlanarMechanics.Types.Defaults.ForceColor
     "Color of force arrow"
     annotation (HideResult=true, Dialog(colorSelector=true, group="if animation = true", enable=animation));
   input MB.Types.SpecularCoefficient specularCoefficient = planarWorld.defaultSpecularCoefficient

--- a/PlanarMechanics/Sensors/CutForceAndTorque.mo
+++ b/PlanarMechanics/Sensors/CutForceAndTorque.mo
@@ -31,10 +31,10 @@ model CutForceAndTorque "Measure cut force vector and cut torque"
   input Real Nm_to_m(unit="N.m/m") = planarWorld.defaultNm_to_m
     "Torque arrow scaling (length = torque/Nm_to_m)"
     annotation (Dialog(group="if animation = true", enable=animation));
-  input MB.Types.Color forceColor = Modelica.Mechanics.MultiBody.Types.Defaults.ForceColor
+  input MB.Types.Color forceColor = PlanarMechanics.Types.Defaults.ForceColor
     "Color of force arrow"
     annotation (HideResult=true, Dialog(colorSelector=true, group="if animation = true", enable=animation));
-  input MB.Types.Color torqueColor = Modelica.Mechanics.MultiBody.Types.Defaults.TorqueColor
+  input MB.Types.Color torqueColor = PlanarMechanics.Types.Defaults.TorqueColor
     "Color of torque arrow"
     annotation (HideResult=true, Dialog(colorSelector=true, group="if animation = true", enable=animation));
   input MB.Types.SpecularCoefficient specularCoefficient = planarWorld.defaultSpecularCoefficient

--- a/PlanarMechanics/Sensors/CutTorque.mo
+++ b/PlanarMechanics/Sensors/CutTorque.mo
@@ -19,7 +19,7 @@ model CutTorque "Measure cut torque"
   input Real Nm_to_m(unit="N.m/m") = planarWorld.defaultNm_to_m
     "Torque arrow scaling (length = torque/Nm_to_m)"
     annotation (Dialog(group="if animation = true", enable=animation));
-  input MB.Types.Color torqueColor = Modelica.Mechanics.MultiBody.Types.Defaults.TorqueColor
+  input MB.Types.Color torqueColor = PlanarMechanics.Types.Defaults.TorqueColor
     "Color of torque arrow"
     annotation (HideResult=true, Dialog(colorSelector=true, group="if animation = true", enable=animation));
   input MB.Types.SpecularCoefficient specularCoefficient = planarWorld.defaultSpecularCoefficient

--- a/PlanarMechanics/Sensors/Distance.mo
+++ b/PlanarMechanics/Sensors/Distance.mo
@@ -4,9 +4,6 @@ model Distance
   extends PlanarMechanics.Interfaces.PartialTwoFrames;
   extends Modelica.Icons.RectangularSensor;
 
-  import Modelica.Mechanics.MultiBody.Frames;
-  import Modelica.Mechanics.MultiBody.Types;
-
   Modelica.Blocks.Interfaces.RealOutput distance(
     final quantity = "Position",
     final unit = "m",
@@ -21,10 +18,10 @@ model Distance
   input SI.Diameter arrowDiameter = planarWorld.defaultArrowDiameter
     "Diameter of relative arrow from frame_a to frame_b"
     annotation (Dialog(group="if animation = true", enable=animation));
-  input Types.Color arrowColor = Modelica.Mechanics.MultiBody.Types.Defaults.SensorColor
+  input MB.Types.Color arrowColor = PlanarMechanics.Types.Defaults.SensorColor
     "Color of relative arrow from frame_a to frame_b"
     annotation (HideResult=true, Dialog(colorSelector=true, group="if animation = true", enable=animation));
-  input Types.SpecularCoefficient specularCoefficient = planarWorld.defaultSpecularCoefficient
+  input MB.Types.SpecularCoefficient specularCoefficient = planarWorld.defaultSpecularCoefficient
     "Reflection of ambient light (= 0: light is completely absorbed)"
     annotation (HideResult=true, Dialog(group="if animation = true", enable=animation));
   input SI.Position s_small(min=sqrt(Modelica.Constants.small)) = 1.E-10

--- a/PlanarMechanics/UsersGuide/ReleaseNotes.mo
+++ b/PlanarMechanics/UsersGuide/ReleaseNotes.mo
@@ -88,6 +88,10 @@ It is <strong>not</strong> backwards compatible to previous library versions.
 <p>Improvements:</p>
 <ul>
   <li>
+    Library colors from
+    <a href=\"modelica://PlanarMechanics.Types.Defaults\">PlanarMechanics.Types.Defaults</a> are used consequently.
+  </li>
+  <li>
     <a href=\"modelica://PlanarMechanics.Sources.QuadraticSpeedDependentForce\">QuadraticSpeedDependentForce</a>:
     fix false type of parameter <code>resolveInFrame</code>. The type
     <a href=\"modelica://Modelica.Mechanics.MultiBody.Types.ResolveInFrameB\">Modelica.Mechanics.MultiBody.Types.ResolveInFrameB</a>


### PR DESCRIPTION
In some cases, colors from MSL were used previously. This is fixed with this PR, so only colors from PlanarMechanics.Types.Defaults are used throughout the Library.
Close #222 