### PR TITLE
Classify Modelica not as Motoko for GitHub Linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -25,3 +25,5 @@ LICENSE text
 README.md export-ignore
 PlanarMechanics/Resources/ReferenceVariables export-ignore
 PlanarMechanicsTest export-ignore
+
+*.mo linguist-language=Modelica


### PR DESCRIPTION
Cf. https://github.com/modelica/ModelicaStandardLibrary/pull/4442